### PR TITLE
test: add missing _c_unused_

### DIFF
--- a/src/test-api.c
+++ b/src/test-api.c
@@ -12,14 +12,14 @@
 static _c_const_ int const_fn(void) { return 0; }
 static _c_deprecated_ _c_unused_ int deprecated_fn(void) { return 0; }
 _c_hidden_ int c_internal_hidden_fn(void) { return 0; }
-static _c_printf_(1, 2) int printf_fn(const char *f, ...) { return 0; }
+static _c_printf_(1, 2) int printf_fn(const _c_unused_ char *f, ...) { return 0; }
 _c_public_ int c_internal_public_fn(void) { return 0; }
 static _c_pure_ int pure_fn(void) { return 0; }
-static _c_sentinel_ int sentinel_fn(const char *f, ...) { return 0; }
+static _c_sentinel_ int sentinel_fn(const _c_unused_ char *f, ...) { return 0; }
 static _c_unused_ int unused_fn(void) { return 0; }
 
-static void cleanup_fn(int p) {}
-static void direct_cleanup_fn(int p) {}
+static void cleanup_fn(_c_unused_ int p) {}
+static void direct_cleanup_fn(_c_unused_ int p) {}
 C_DEFINE_CLEANUP(int, cleanup_fn);
 C_DEFINE_DIRECT_CLEANUP(int, direct_cleanup_fn);
 
@@ -202,7 +202,7 @@ static void test_api_functions(void) {
                 c_assert(!!fns[i]);
 }
 
-int main(int argc, char **argv) {
+int main(_c_unused_ int argc, _c_unused_ char **argv) {
         test_api_macros();
         test_api_functions();
         return 0;

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -425,7 +425,7 @@ static void test_destructors(void) {
         }
 }
 
-int main(int argc, char **argv) {
+int main(_c_unused_ int argc, _c_unused_ char **argv) {
         test_misc(argc);
         test_destructors();
         return 0;


### PR DESCRIPTION
When configuring the build dir with `meson -Dwarning_level=2 builddir` (or when doing that in a superproject) some warnings are thrown for the unused variables in the test sources. 