### PR TITLE
Main unused args

### DIFF
--- a/src/test-api.c
+++ b/src/test-api.c
@@ -202,7 +202,7 @@ static void test_api_functions(void) {
                 c_assert(!!fns[i]);
 }
 
-int main(_c_unused_ int argc, _c_unused_ char **argv) {
+int main(void) {
         test_api_macros();
         test_api_functions();
         return 0;

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -425,7 +425,7 @@ static void test_destructors(void) {
         }
 }
 
-int main(_c_unused_ int argc, _c_unused_ char **argv) {
+int main(int argc, _c_unused_ char **argv) {
         test_misc(argc);
         test_destructors();
         return 0;


### PR DESCRIPTION
This is just a follow up to previous merge request; for coherence with c-shquote main arguments have been removed if not used.