### PR TITLE
c-stdaux: introduce c_thread_local macro

### DIFF
--- a/src/c-stdaux.h
+++ b/src/c-stdaux.h
@@ -543,6 +543,23 @@ C_DEFINE_DIRECT_CLEANUP(int, c_close);
 C_DEFINE_CLEANUP(FILE *, c_fclose);
 C_DEFINE_CLEANUP(DIR *, c_closedir);
 
+/*
+ * Thread-local storage
+ */
+#ifdef thread_local
+#define c_thread_local thread_local
+/*
+ * C11 introduces _Thread_local. glibc < 2.16 doesn't support it and
+ * doesn't define __STDC_NO_THREADS__. See
+ * http://gcc.gnu.org/bugzilla/show_bug.cgi?id=53769
+ */
+#elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__) \
+    && !(defined(__GNU_LIBRARY__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 16)
+#define c_thread_local _Thread_local
+#else
+#define c_thread_local __thread
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/test-api.c
+++ b/src/test-api.c
@@ -184,6 +184,13 @@ static void test_api_macros(void) {
                 cleanup_fnp(&v);
                 direct_cleanup_fnp(&v);
         }
+
+        /* c_thread_local */
+        {
+                static c_thread_local int i;
+
+                c_assert(i == 0);
+        }
 }
 
 static void test_api_functions(void) {


### PR DESCRIPTION
Introduce a `c_thread_local` macro to mark a variable with thread storage duration, supporting different compiler and libc versions.