### PR TITLE
c-stdaux.h: avoid <stdatomic.h> in gcc 4.8 and older

### DIFF
--- a/src/c-stdaux.h
+++ b/src/c-stdaux.h
@@ -57,7 +57,6 @@ extern "C" {
 #include <limits.h>
 #include <stdalign.h>
 #include <stdarg.h>
-#include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>


### PR DESCRIPTION
c-stdaux is a C11 library, so it's reasonably to require C11 features.
However, RHEL7 comes with gcc 4.8, which has only partial C11 support.
In many aspects it works well enough, except that `<stdatomic.h>` is missing
([1], [2]).

The includes which "c-stdaux.h" provides are part of its API.
Including `<stdatomic.h>` conditionally means that the actual API
depends on the build environment. But it's always the case that
the libc features provided by c-stdaux depend on libc and the
environment.

Based on the GCC version, avoid including the header. Then at least
we can build and use the rest of the API. Not every user of c-stdaux
cares about <stdatomic.h>, and neither does c-stdaux itself
require it.

The `<stdatomic.h>` header is only supported since gcc-4.9 ([3]).

[1] https://stackoverflow.com/questions/20326604/stdatomic-h-in-gcc-4-8
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016
[3] https://gcc.gnu.org/gcc-4.9/changes.html