### PR TITLE
[th/preserve-wparentheses-warn] add _c_boolean_expr_() to preseve -Wparentheses warning

### DIFF
--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -264,7 +264,7 @@ extern "C" {
  * optimize it away.
  */
 #define c_assert(_x) (                                                          \
-                (bool)(_x)                                                      \
+                _c_likely_(_x)                                                  \
                         ? assert(true && #_x)                                   \
                         : assert(false && #_x)                                  \
         )

--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -120,6 +120,41 @@ extern "C" {
 #endif
 
 /**
+ * _c_boolean_expr_() - Evaluate a boolean expression
+ * @_x:                 Expression to evaluate
+ *
+ * Evaluate the given expression and convert the result to 1 or 0. In most
+ * cases this is equivalent to ``(!!(_x))``. However, for given compilers this
+ * avoids the parentheses to improve diagnostics with ``-Wparentheses``.
+ *
+ * Outside of macros, this has no added value.
+ *
+ * Return: Evaluates to the value of ``!!_x``.
+ */
+#define _c_boolean_expr_(_x) _c_internal_boolean_expr_(__COUNTER__, _x)
+#if defined(C_COMPILER_GNUC)
+#  define _c_internal_boolean_expr_(_uniq, _x)                                  \
+        __extension__ ({                                                        \
+                int C_VAR(b, _uniq);                                            \
+                                                                                \
+                /*                                                              \
+                 * Avoid any extra parentheses around the evaluation of `_x` to \
+                 * allow `-Wparentheses` to warn about use of `x = ...` and     \
+                 * instead suggest `(x = ...)` or `x == ...`.                   \
+                 */                                                             \
+                                                                                \
+                if (_x)                                                         \
+                        C_VAR(b, _uniq) = 1;                                    \
+                else                                                            \
+                        C_VAR(b, _uniq) = 0;                                    \
+                                                                                \
+                C_VAR(b, _uniq);                                                \
+        })
+#else
+#  define _c_internal_boolean_expr_(_uniq, _x) (!!(_x))
+#endif
+
+/**
  * _c_likely_() - Likely attribute
  * @_x:                 Expression to evaluate
  *

--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -164,9 +164,9 @@ extern "C" {
  */
 #define _c_likely_(_x) _c_internal_likely_(_x)
 #if defined(C_COMPILER_GNUC)
-#  define _c_internal_likely_(_x) (__builtin_expect(!!(_x), 1))
+#  define _c_internal_likely_(_x) (__builtin_expect(_c_boolean_expr_(_x), 1))
 #else
-#  define _c_internal_likely_(_x) (!!(_x))
+#  define _c_internal_likely_(_x) (_c_boolean_expr_(_x))
 #endif
 
 /**
@@ -200,9 +200,9 @@ extern "C" {
  */
 #define _c_unlikely_(_x) _c_internal_unlikely_(_x)
 #if defined(C_COMPILER_GNUC)
-#  define _c_internal_unlikely_(_x) (__builtin_expect(!!(_x), 0))
+#  define _c_internal_unlikely_(_x) (__builtin_expect(_c_boolean_expr_(_x), 0))
 #else
-#  define _c_internal_unlikely_(_x) (!!(_x))
+#  define _c_internal_unlikely_(_x) (_c_boolean_expr_(_x))
 #endif
 
 /**


### PR DESCRIPTION
gcc has a useful warning `-Wparentheses`, for anti patterns like `if (x =1) ...`, which suggests to either use "==" or put the assignment in a parentheses.

Inside macros (like `c_assert()`) we need to make sure to add proper parentheses around the macro arguments, but if we just always add them, we hide the useful warning.

Add `_c_boolean_expr_()` which with GCC uses and expression statement and `__COUNTER__` to evaluate the expression to 0 or 1, without hiding `-Wparentheses`. And use it from `_c_likely_()`, `_c_unlikely_()`, `c_assert()`.

This is also done by [glib](https://gitlab.gnome.org/GNOME/glib/-/blob/ad755e748952161c15cee60d144550c09e88a3b2/glib/gmacros.h#L1221) and [NetworkManager](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/0be1b4d95d335125cd4a32a0d9a659bf6287fbb2/src/libnm-std-aux/nm-std-aux.h#L168).

```
In file included from ../src/c-stdaux.h:43,
                 from ../src/test-api.c:10:
../src/test-api.c: In function ‘test_api_unix’:
../src/test-api.c:274:26: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  274 |                 c_assert(i = 1);
      |                          ^
../src/c-stdaux-generic.h:143:37: note: in definition of macro ‘_c_boolean_expr_impl_’
  143 |                                 if (_x)                                         \
      |                                     ^~
../src/c-stdaux-generic.h:166:53: note: in expansion of macro ‘_c_boolean_expr_’
  166 | #  define _c_internal_likely_(_x) (__builtin_expect(_c_boolean_expr_(_x), 1))
      |                                                     ^~~~~~~~~~~~~~~~
../src/c-stdaux-generic.h:164:24: note: in expansion of macro ‘_c_internal_likely_’
  164 | #define _c_likely_(_x) _c_internal_likely_(_x)
      |                        ^~~~~~~~~~~~~~~~~~~
../src/c-stdaux-generic.h:301:17: note: in expansion of macro ‘_c_likely_’
  301 |                 _c_likely_(_x)                                                  \
      |                 ^~~~~~~~~~
../src/test-api.c:274:17: note: in expansion of macro ‘c_assert’
  274 |                 c_assert(i = 1);
      |                 ^~~~~~~~
```