### PR TITLE
generic: handle compile time expression in _c_likely_()/_c_unlikely_()

### DIFF
--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -132,24 +132,28 @@ extern "C" {
  * Return: Evaluates to the value of ``!!_x``.
  */
 #define _c_boolean_expr_(_x) _c_internal_boolean_expr_(__COUNTER__, _x)
-#if defined(C_COMPILER_GNUC)
+#if defined(C_COMPILER_GNUC) && __GNUC__ > 4
 #  define _c_internal_boolean_expr_(_uniq, _x)                                  \
-        __extension__ ({                                                        \
-                int C_VAR(b, _uniq);                                            \
+        __builtin_choose_expr(                                                  \
+                __builtin_constant_p(_x),                                       \
+                (!!(_x)),                                                       \
+                (__extension__ ({                                               \
+                        int C_VAR(b, _uniq);                                    \
                                                                                 \
-                /*                                                              \
-                 * Avoid any extra parentheses around the evaluation of `_x` to \
-                 * allow `-Wparentheses` to warn about use of `x = ...` and     \
-                 * instead suggest `(x = ...)` or `x == ...`.                   \
-                 */                                                             \
+                        /*                                                      \
+                         * Avoid any extra parentheses around the evaluation of \
+                         * `_x` to allow `-Wparentheses` to warn about use of   \
+                         * `x = ...` and instead suggest `(x = ...)` or         \
+                         * `x == ...`.                                          \
+                         */                                                     \
                                                                                 \
-                if (_x)                                                         \
-                        C_VAR(b, _uniq) = 1;                                    \
-                else                                                            \
-                        C_VAR(b, _uniq) = 0;                                    \
+                        if (_x)                                                 \
+                                C_VAR(b, _uniq) = 1;                            \
+                        else                                                    \
+                                C_VAR(b, _uniq) = 0;                            \
                                                                                 \
-                C_VAR(b, _uniq);                                                \
-        })
+                        C_VAR(b, _uniq);                                        \
+                })))
 #else
 #  define _c_internal_boolean_expr_(_uniq, _x) (!!(_x))
 #endif


### PR DESCRIPTION
We now use _c_likely_() inside c_assert(), and _c_likely_() uses _c_boolean_expr_(). The latter is no longer obviously a compile time constant, and the compiler cannot clearly see that c_assert(0) is an unreachable code path.

This means for example, if you have a switch statement and the default case contains "c_assert(0)", then the compiler will now think that this code path can be taken. If you then afterwards access a variable that is initialized in all other switch branches, you get a "-Wsometimes-uninitialized" warning. This happens with clang-15.0.4-1.fc37 and n-dhcp4. See [1].

Work around that by using __builtin_constant_p() in _c_likely_()/ _c_unlikely_(). As we are already inside a C_COMPILER_GNUC check, that is easy to do.

This also has the added benefit that now _c_likely_() is a compile time constant, if the argument is. While that is not directly useful, you might get into that situation when using a macro that uses _c_likely_(), like with c_assert().

[1] https://github.com/c-util/c-stdaux/pull/11#issuecomment-1331233011

Signed-off-by: Thomas Haller <thaller@redhat.com>