### PR TITLE
[th/assume-aligned-fixes] fix c_internal_assume_aligned() for clang 3.4

### DIFF
--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -304,7 +304,7 @@ extern "C" {
  * Return: `_ptr` is returned.
  */
 #define c_assume_aligned(_ptr, _alignment, _offset) c_internal_assume_aligned((_ptr), (_alignment), (_offset))
-#if defined(C_COMPILER_GNUC)
+#if defined(C_COMPILER_GNUC) && (!defined(__clang__) || __clang_major__ > 3)
 #  define c_internal_assume_aligned(_ptr, _alignment, _offset) __builtin_assume_aligned((_ptr), (_alignment), (_offset))
 #else
 #  define c_internal_assume_aligned(_ptr, _alignment, _offset) ((_alignment), (_offset), (_ptr))

--- a/src/c-stdaux-generic.h
+++ b/src/c-stdaux-generic.h
@@ -307,7 +307,7 @@ extern "C" {
 #if defined(C_COMPILER_GNUC) && (!defined(__clang__) || __clang_major__ > 3)
 #  define c_internal_assume_aligned(_ptr, _alignment, _offset) __builtin_assume_aligned((_ptr), (_alignment), (_offset))
 #else
-#  define c_internal_assume_aligned(_ptr, _alignment, _offset) ((_alignment), (_offset), (_ptr))
+#  define c_internal_assume_aligned(_ptr, _alignment, _offset) ((void)(_alignment), (void)(_offset), (_ptr))
 #endif
 
 /**


### PR DESCRIPTION
clang 3.4 is on Centos7. It currently fails to build `src/c-stdaux-generic.h` due to `c_assume_aligned()`.