### PR TITLE
Fix incorrect __builtin_constant_p test for c_align_to

### DIFF
--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -545,7 +545,7 @@ static void test_basic_gnuc(int non_constant_expr) {
                 c_assert(__builtin_constant_p(c_align_to(16, 8)));
                 c_assert(!__builtin_constant_p(c_align_to(non_constant_expr, 8)));
                 c_assert(!__builtin_constant_p(c_align_to(16, non_constant_expr)));
-                c_assert(!__builtin_constant_p(c_align_to(16, non_constant_expr ? 8 : 16)));
+                c_assert(!__builtin_constant_p(c_align_to(8, non_constant_expr ? 8 : 16)));
                 c_assert(__builtin_constant_p(c_align_to(16, 7 + 1)));
                 c_assert(c_align_to(15, non_constant_expr ? 8 : 16) == 16);
         }


### PR DESCRIPTION
16 aligned to 8 or 16 will always be 16, so it is legal for __builtin_constant_p to return true here, and Clang indeed performs this optimization (while GCC does not).

Adjust the argument to 8, in which case the result of the expression is not a known constant.